### PR TITLE
Avoid possible ConfigurationConflictError on upgrade step registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Avoid possible ``ConfigurationConflictError`` on upgrade step registration.
+  [hvelarde]
 
 
 3.0.0 (2017-03-09)

--- a/src/collective/lazysizes/upgrades/v2/configure.zcml
+++ b/src/collective/lazysizes/upgrades/v2/configure.zcml
@@ -18,6 +18,7 @@
     <genericsetup:upgradeDepends
         title="Add new field to configlet"
         description="Reload registration of configlet registry to add new field."
+        import_profile="collective.lazysizes:default"
         import_steps="plone.app.registry"
         run_deps="false"
         />


### PR DESCRIPTION
refs. https://github.com/collective/collective.newsticker/issues/29