### PR TITLE
Add browser layer to collective.lazysizes.resources viewlet registration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,9 @@ Changelog
 4.1.1.2 (unreleased)
 --------------------
 
-- Nothing changed yet.
+- Add browser layer to ``collective.lazysizes.resources`` viewlet registration;
+  this avoids showing the viewlet when the package is not yet installed (fixes `#69 <https://github.com/collective/collective.lazysizes/issues/69>`_).
+  [hvelarde]
 
 
 4.1.1.1 (2018-09-10)

--- a/src/collective/lazysizes/browser/configure.zcml
+++ b/src/collective/lazysizes/browser/configure.zcml
@@ -15,6 +15,7 @@
       class=".ResourcesViewlet"
       template="static/resources.pt"
       permission="zope2.Public"
+      layer="collective.lazysizes.interfaces.ILazySizesLayer"
       />
 
 </configure>


### PR DESCRIPTION
This avoids showing the viewlet when the package is not yet installed.