### PR TITLE
Fix testing layers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: python
 python: 2.7
 sudo: false
+services:
+  - xvfb
 cache:
   directories:
   - $HOME/.pylint.d
@@ -26,8 +28,6 @@ install:
 - bin/buildout annotate
 - bin/buildout
 before_script:
-- export DISPLAY=:99.0
-- sh -e /etc/init.d/xvfb start
 - firefox -v
 script:
 - bin/code-analysis

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,8 @@ Changelog
 4.1.7 (unreleased)
 ------------------
 
-- Nothing changed yet.
-
+- Fix layer teardown when using the `FIXTURE` from `testing.py` on other packages.
+  [gforcada]
 
 4.1.6 (2019-03-12)
 ------------------

--- a/src/collective/lazysizes/testing.py
+++ b/src/collective/lazysizes/testing.py
@@ -9,6 +9,7 @@ from plone.app.robotframework.testing import AUTOLOGIN_LIBRARY_FIXTURE
 from plone.app.testing import FunctionalTesting
 from plone.app.testing import IntegrationTesting
 from plone.app.testing import PloneSandboxLayer
+from plone.app.testing import PLONE_FIXTURE
 from plone.testing import z2
 
 import pkg_resources
@@ -16,10 +17,10 @@ import pkg_resources
 
 try:
     pkg_resources.get_distribution('plone.app.contenttypes')
+    from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE
+    HAS_PAC = True
 except pkg_resources.DistributionNotFound:
-    from plone.app.testing import PLONE_FIXTURE
-else:
-    from plone.app.contenttypes.testing import PLONE_APP_CONTENTTYPES_FIXTURE as PLONE_FIXTURE
+    HAS_PAC = False
 
 IS_BBB = api.env.plone_version().startswith('4.3')
 
@@ -55,11 +56,15 @@ class Fixture(PloneSandboxLayer):
 
 FIXTURE = Fixture()
 
+bases = (FIXTURE, )
+if HAS_PAC:
+    bases = (PLONE_APP_CONTENTTYPES_FIXTURE, FIXTURE)
+
 INTEGRATION_TESTING = IntegrationTesting(
-    bases=(FIXTURE,), name='collective.lazysizes:Integration')
+    bases=bases, name='collective.lazysizes:Integration')
 
 FUNCTIONAL_TESTING = FunctionalTesting(
-    bases=(FIXTURE,), name='collective.lazysizes:Functional')
+    bases=bases, name='collective.lazysizes:Functional')
 
 ROBOT_TESTING = FunctionalTesting(
     bases=(FIXTURE, AUTOLOGIN_LIBRARY_FIXTURE, z2.ZSERVER_FIXTURE),


### PR DESCRIPTION
I've been scratching my head over this for 3 days: without this fixes tests run fine but raise a `AttributeError: 'DB' object has no attribute '_mvcc_storage'` when tearing down layers:

```
Tearing down left over layers:
  Tear down der.freitag.testing.DerFreitagLayer:Integration in 0.000 seconds.
  Tear down der.freitag.testing.DerFreitagLayer in 0.033 seconds.
  Tear down collective.solr.testing.CollectiveSolr:Integration in 0.000 seconds.
  Tear down plone.app.contenttypes.testing.PloneAppContenttypes in 0.046 seconds.
  Tear down plone.app.event.testing.PAEventLayer Traceback (most recent call last):
  File "./bin/test", line 353, in <module>
    '--test-path', '/home/gil/Documents/freitag/git/zope-next/src/freitag.util.relations/src',
  File "/home/gil/.buildout/eggs/collective.xmltestreport-2.0.1-py2.7.egg/collective/xmltestreport/runner.py", line 66, in run
    failed = run_internal(defaults, args, script_parts=script_parts)
  File "/home/gil/.buildout/eggs/collective.xmltestreport-2.0.1-py2.7.egg/collective/xmltestreport/runner.py", line 79, in run_internal
    runner.run()
  File "/home/gil/.buildout/eggs/zope.testrunner-5.0-py2.7.egg/zope/testrunner/runner.py", line 191, in run
    self.run_tests()
  File "/home/gil/.buildout/eggs/zope.testrunner-5.0-py2.7.egg/zope/testrunner/runner.py", line 320, in run_tests
    tear_down_unneeded(self.options, (), setup_layers, True)
  File "/home/gil/.buildout/eggs/zope.testrunner-5.0-py2.7.egg/zope/testrunner/runner.py", line 764, in tear_down_unneeded
    l.tearDown()
  File "/home/gil/.buildout/eggs/plone.app.testing-6.1.3-py2.7.egg/plone/app/testing/helpers.py", line 393, in tearDown
    with zope.zopeApp() as app:
  File "/usr/lib64/python2.7/contextlib.py", line 17, in __enter__
    return self.gen.next()
  File "/home/gil/.buildout/eggs/plone.testing-7.0.3-py2.7.egg/plone/testing/zope.py", line 242, in zopeApp
    app = addRequestContainer(Zope2.app(connection), environ=environ)
  File "/home/gil/.buildout/eggs/Zope-4.1.3-py2.7.egg/Zope2/__init__.py", line 56, in app
    return bobo_application(*args, **kw)
  File "/home/gil/.buildout/eggs/Zope-4.1.3-py2.7.egg/App/ZApplication.py", line 75, in __call__
    connection = db.open()
  File "/home/gil/.buildout/eggs/ZODB-5.5.1-py2.7.egg/ZODB/DB.py", line 781, in open
    self._cache_size_bytes,
  File "/home/gil/.buildout/eggs/ZODB-5.5.1-py2.7.egg/ZODB/Connection.py", line 116, in __init__
    storage = db._mvcc_storage
AttributeError: 'DB' object has no attribute '_mvcc_storage'
```